### PR TITLE
Honeycomb/ICS fix regarding WidgetFrame visibility

### DIFF
--- a/src/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/src/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -101,6 +101,7 @@ public class ColorPickerPreference
 		ImageView iView = new ImageView(getContext());
 		LinearLayout widgetFrameView = ((LinearLayout)mView.findViewById(android.R.id.widget_frame));
 		if (widgetFrameView == null) return;
+		widgetFrameView.setVisibility(View.VISIBLE);
 		widgetFrameView.setPadding(
 			widgetFrameView.getPaddingLeft(),
 			widgetFrameView.getPaddingTop(),


### PR DESCRIPTION
Honeycomb/ICS fix. WidgetFrame is not visible per default. This will set the widgetframe to visible. This is tested fixing the missing color preview in Android 4.0.3.

See Stack Overflow: http://stackoverflow.com/questions/8762984/custom-preference-broken-in-honeycomb-ic
