### PR TITLE
Fix: Restore color picker after rotating

### DIFF
--- a/src/net/margaritov/preference/colorpicker/ColorPickerDialog.java
+++ b/src/net/margaritov/preference/colorpicker/ColorPickerDialog.java
@@ -16,11 +16,10 @@
 
 package net.margaritov.preference.colorpicker;
 
-import net.margaritov.preference.colorpicker.R;
-
 import android.app.Dialog;
 import android.content.Context;
 import android.graphics.PixelFormat;
+import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -126,4 +125,18 @@ public class ColorPickerDialog
 		dismiss();
 	}
 	
+	@Override
+	public Bundle onSaveInstanceState() {
+		Bundle state = super.onSaveInstanceState();
+		state.putInt("old_color", mOldColor.getColor());
+		state.putInt("new_color", mNewColor.getColor());
+		return state;
+	}
+	
+	@Override
+	public void onRestoreInstanceState(Bundle savedInstanceState) {
+		super.onRestoreInstanceState(savedInstanceState);
+		mOldColor.setColor(savedInstanceState.getInt("old_color"));
+		mColorPicker.setColor(savedInstanceState.getInt("new_color"), true);
+	}
 }


### PR DESCRIPTION
When trying out the color picker, I noticed that the color picker dialog disappears if I rotate my phone while it is shown (that is with ICS on SGS2). These changes restore the dialog after the rotation, similar to the DialogPreference. Both old and new color are remembered, but nothing is persisted until the user explicitely asks for it.
