### PR TITLE
Fix for perisisting defaultValue attr

### DIFF
--- a/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -66,15 +66,7 @@ public class ColorPickerPreference
 
     @Override
     protected Object onGetDefaultValue(TypedArray a, int index) {
-        int colorInt;
-        String mHexDefaultValue = a.getString(index);
-        if (mHexDefaultValue != null && mHexDefaultValue.startsWith("#")) {
-            colorInt = convertToColorInt(mHexDefaultValue);
-            return colorInt;
-
-        } else {
-            return a.getColor(index, Color.BLACK);
-        }
+        return a.getColor(index, Color.BLACK);
     }
 
     @Override

--- a/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -66,7 +66,15 @@ public class ColorPickerPreference
 
     @Override
     protected Object onGetDefaultValue(TypedArray a, int index) {
-        return a.getColor(index, Color.BLACK);
+        int colorInt;
+        String mHexDefaultValue = a.getString(index);
+        if (mHexDefaultValue != null) {
+            colorInt = convertToColorInt(mHexDefaultValue);
+            return colorInt;
+
+        } else {
+            return a.getColor(index, Color.BLACK);
+        }
     }
 
     @Override

--- a/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -66,7 +66,15 @@ public class ColorPickerPreference
 
     @Override
     protected Object onGetDefaultValue(TypedArray a, int index) {
-        return a.getColor(index, Color.BLACK);
+        int colorInt;
+        String mHexDefaultValue = a.getString(index);
+        if (mHexDefaultValue != null && mHexDefaultValue.startsWith("#")) {
+            colorInt = convertToColorInt(mHexDefaultValue);
+            return colorInt;
+
+        } else {
+            return a.getColor(index, Color.BLACK);
+        }
     }
 
     @Override

--- a/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -64,6 +64,11 @@ public class ColorPickerPreference
         init(context, attrs);
     }
 
+    /**Method edited by
+     * @author Anna Berkovitch
+     * added functionality to accept hex string as defaultValue
+     * and to properly persist resources reference string, such as @color/someColor
+     * previously persisted 0*/
     @Override
     protected Object onGetDefaultValue(TypedArray a, int index) {
         int colorInt;
@@ -225,7 +230,8 @@ public class ColorPickerPreference
     }
 
     /**
-     * For custom purposes. Not used by ColorPickerPreference
+     * Method currently used by onGetDefaultValue method to
+     * convert hex string provided in android:defaultValue to color integer.
      *
      * @param color
      * @return A string representing the hex value of color,

--- a/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/ColorPickerPreference/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -68,7 +68,7 @@ public class ColorPickerPreference
     protected Object onGetDefaultValue(TypedArray a, int index) {
         int colorInt;
         String mHexDefaultValue = a.getString(index);
-        if (mHexDefaultValue != null) {
+        if (mHexDefaultValue != null && mHexDefaultValue.startsWith("#")) {
             colorInt = convertToColorInt(mHexDefaultValue);
             return colorInt;
 


### PR DESCRIPTION
I have noticed that when you set defaultValue you can only set it as an actual color integer.

1. If you set it as hex string it crashes, as it expects integer
2. If you set it as reference to resources color, it persists 0 into shared preferences

Method onGetDefaultValue was modified to look for a string and if it is not null or begins with hash, to use built in method to parse hex string into color integer and return it as default. Color hex can only be used with 6 or 8 chars. If the string is null, it will look for an integer and use it.

Now default can be set as:
1. Color integer
2. Hex string (#ffffff or #ffffffff)
3. Resource reference will be parsed as hex string and return valid color integer

Only the last commit is relevant actually. I had to add condition for the not breaking the integer defaultValue